### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -19,10 +19,9 @@ matrix:
   allow_failures:
     - php: hhvm-3.18
 
-sudo: false
-
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
         "react/promise-timer": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^5.0 || ^4.8"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Connection-Manager-Extra Test Suite">
-            <directory>./tests</directory>
+            <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Connection-Manager-Extra Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,7 +53,13 @@ class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 9+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
     }
 
     protected function createConnectionManagerMock($ret)
@@ -86,16 +92,20 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
 
-    public function setExpectedException($exception, $message = '', $code = 0)
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
     {
         if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
             $this->expectException($exception);
-            if ($message !== '') {
-                $this->expectExceptionMessage($message);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
             }
-            $this->expectExceptionCode($code);
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
         } else {
-            parent::setExpectedException($exception, $message, $code);
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
         }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #27.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.4.1 by Sebastian Bergmann and contributors.

..................................................                50 / 50 (100%)

Time: 00:00.347, Memory: 6.00 MB

OK (50 tests, 170 assertions)
```