### PR TITLE
Support PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ $ composer require clue/connection-manager-extra:^1.1
 
 See also the [CHANGELOG](CHANGELOG.md) for more details about version upgrades.
 
+This project aims to run on any platform and thus does not require any PHP
+extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
+HHVM.
+It's *highly recommended to use PHP 7+* for this project.
+
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all


### PR DESCRIPTION
It's possible to run this code with PHP 8 🎉

This pull request builds on top of #28 and #29.

 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0 php vendor/bin/phpunit
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

..................................................                50 / 50 (100%)

Time: 00:00.365, Memory: 6.00 MB

OK (50 tests, 170 assertions)
```