### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,20 +92,20 @@ $connectorRepeater->connect('www.google.com:80')->then(function ($stream) {
 
 ### Timeout
 
-The `ConnectionManagerTimeout($connector, $timeout, $loop)` sets a maximum `$timeout` in seconds on when to give up
+The `ConnectionManagerTimeout($connector, $timeout, $loop = null)` sets a maximum `$timeout` in seconds on when to give up
 waiting for the connection to complete.
 
 ```php
-$connector = new ConnectionManagerTimeout($connector, 3.0, $loop);
+$connector = new ConnectionManagerTimeout($connector, 3.0);
 ```
 
 ### Delay
 
-The `ConnectionManagerDelay($connector, $delay, $loop)` sets a fixed initial `$delay` in seconds before actually
+The `ConnectionManagerDelay($connector, $delay, $loop = null)` sets a fixed initial `$delay` in seconds before actually
 trying to connect. (Not to be confused with [`ConnectionManagerTimeout`](#timeout) which sets a _maximum timeout_.)
 
 ```php
-$delayed = new ConnectionManagerDelayed($connector, 0.5, $loop);
+$delayed = new ConnectionManagerDelayed($connector, 0.5);
 ```
 
 ### Reject
@@ -221,11 +221,11 @@ retrying unreliable hosts:
 
 ```php
 // delay connection by 2 seconds
-$delayed = new ConnectionManagerDelay($connector, 2.0, $loop);
+$delayed = new ConnectionManagerDelay($connector, 2.0);
 
 // maximum of 3 tries, each taking no longer than 2.0 seconds
 $retry = new ConnectionManagerRepeat(
-    new ConnectionManagerTimeout($connector, 2.0, $loop),
+    new ConnectionManagerTimeout($connector, 2.0),
     3
 );
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3",
         "react/socket": "^1.0 || ^0.8 || ^0.7",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.1 || ^1.2.1",
         "react/promise-timer": "^1.1"
     },

--- a/src/ConnectionManagerDelay.php
+++ b/src/ConnectionManagerDelay.php
@@ -2,9 +2,10 @@
 
 namespace ConnectionManager\Extra;
 
-use React\Socket\ConnectorInterface;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Timer;
+use React\Socket\ConnectorInterface;
 
 class ConnectionManagerDelay implements ConnectorInterface
 {
@@ -12,11 +13,11 @@ class ConnectionManagerDelay implements ConnectorInterface
     private $delay;
     private $loop;
 
-    public function __construct(ConnectorInterface $connectionManager, $delay, LoopInterface $loop)
+    public function __construct(ConnectorInterface $connectionManager, $delay, LoopInterface $loop = null)
     {
         $this->connectionManager = $connectionManager;
         $this->delay = $delay;
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
     }
 
     public function connect($uri)

--- a/src/ConnectionManagerTimeout.php
+++ b/src/ConnectionManagerTimeout.php
@@ -2,9 +2,10 @@
 
 namespace ConnectionManager\Extra;
 
-use React\Socket\ConnectorInterface;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Timer;
+use React\Socket\ConnectorInterface;
 
 class ConnectionManagerTimeout implements ConnectorInterface
 {
@@ -12,11 +13,11 @@ class ConnectionManagerTimeout implements ConnectorInterface
     private $timeout;
     private $loop;
 
-    public function __construct(ConnectorInterface $connectionManager, $timeout, LoopInterface $loop)
+    public function __construct(ConnectorInterface $connectionManager, $timeout, LoopInterface $loop = null)
     {
         $this->connectionManager = $connectionManager;
         $this->timeout = $timeout;
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
     }
 
     public function connect($uri)


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).
Builds on top of reactphp/event-loop#226, reactphp/event-loop#229.